### PR TITLE
Rename project to gemini-code-assist-oauth-proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ node_modules
 *.proxymanlogv2
 build/
 com.gemini-proxy.plist
-/gemini-code-assist-proxy
-npm/gemini-code-assist-proxy
-npm/gemini-code-assist-proxy.exe
+/gemini-code-assist-oauth-proxy
+npm/gemini-code-assist-oauth-proxy
+npm/gemini-code-assist-oauth-proxy.exe
 .gocache

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ node_modules
 *.har
 *.proxymanlogv2
 build/
-com.gemini-proxy.plist
+sh.d.gemini-code-assist-oauth-proxy.plist
 /gemini-code-assist-oauth-proxy
 npm/gemini-code-assist-oauth-proxy
 npm/gemini-code-assist-oauth-proxy.exe

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,11 @@
 version: 2
 
-project_name: gemini-code-assist-proxy
+project_name: gemini-code-assist-oauth-proxy
 
 builds:
-  - id: gemini-code-assist-proxy
-    main: ./cmd/gemini-code-assist-proxy
-    binary: gemini-code-assist-proxy
+  - id: gemini-code-assist-oauth-proxy
+    main: ./cmd/gemini-code-assist-oauth-proxy
+    binary: gemini-code-assist-oauth-proxy
     env:
       - CGO_ENABLED=0
     goos:
@@ -39,7 +39,7 @@ checksum:
 release:
   github:
     owner: dvcrn
-    name: gemini-code-assist-proxy
+    name: gemini-code-assist-oauth-proxy
   replace_existing_artifacts: true
 
 changelog:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ This is a Go proxy server that transforms standard Gemini API requests into Goog
 
 The codebase supports two deployment modes:
 
-1. **Local/Traditional** (`cmd/gemini-code-assist-proxy/`) - Uses FileProvider for credentials
+1. **Local/Traditional** (`cmd/gemini-code-assist-oauth-proxy/`) - Uses FileProvider for credentials
 2. **Cloudflare Workers** (`cmd/gemini-proxy-worker/`) - Uses CloudflareKVProvider for credentials
 
 ### Key Transformations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ This is a Go proxy server that transforms standard Gemini API requests into Goog
 The codebase supports two deployment modes:
 
 1. **Local/Traditional** (`cmd/gemini-code-assist-oauth-proxy/`) - Uses FileProvider for credentials
-2. **Cloudflare Workers** (`cmd/gemini-proxy-worker/`) - Uses CloudflareKVProvider for credentials
+2. **Cloudflare Workers** (`cmd/gemini-code-assist-oauth-proxy-worker/`) - Uses CloudflareKVProvider for credentials
 
 ### Key Transformations
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gemini Code Assist OAuth Proxy
 
 > [!WARNING]
-> Google has deprecated Gemini Code Assist in favor of [Antigravity](https://antigravity.google/). If you're looking for a proxy for Antigravity, check out [antigravity-proxy](https://github.com/dvcrn/antigravity-proxy).
+> Google has deprecated Gemini Code Assist in favor of [Antigravity](https://antigravity.google/). If you're looking for a proxy for Antigravity, check out [antigravity-oauth-proxy](https://github.com/dvcrn/antigravity-oauth-proxy).
 
 Transparently proxy to expose the Gemini Code Assist API through standard APIs that you can plug into different tools such as OpenCode or Xcode
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Gemini Code Assist Proxy
+# Gemini Code Assist OAuth Proxy
+
+> [!WARNING]
+> Google has deprecated Gemini Code Assist in favor of [Antigravity](https://antigravity.google/). If you're looking for a proxy for Antigravity, check out [antigravity-proxy](https://github.com/dvcrn/antigravity-proxy).
 
 Transparently proxy to expose the Gemini Code Assist API through standard APIs that you can plug into different tools such as OpenCode or Xcode
 
@@ -32,19 +35,19 @@ To run locally, or to deploy to Cloudflare Workers
 Option 1 (recommended): prebuilt binary via npm (macOS, Linux, Windows)
 
 ```bash
-npm install -g @dvcrn/gemini-code-assist-proxy
+npm install -g @dvcrn/gemini-code-assist-oauth-proxy
 ```
 
 Option 2: install from source with Go
 
 ```
-go install github.com/dvcrn/gemini-code-assist-proxy/cmd/gemini-code-assist-proxy@latest
+go install github.com/dvcrn/gemini-code-assist-oauth-proxy/cmd/gemini-code-assist-oauth-proxy@latest
 ```
 
 Then to start:
 
 ```
-ADMIN_API_KEY=123abc gemini-code-assist-proxy
+ADMIN_API_KEY=123abc gemini-code-assist-oauth-proxy
 ```
 
 ## Auth
@@ -135,14 +138,14 @@ For production deployment on Cloudflare Workers:
 1. **Create KV namespace** (required for credential storage):
 
    ```bash
-   wrangler kv namespace create "gemini-code-assist-proxy-kv"
+   wrangler kv namespace create "gemini-code-assist-oauth-proxy-kv"
    ```
 
    This will output a namespace ID. Add it to your `wrangler.toml`:
 
    ```toml
    kv_namespaces = [
-     { binding = "gemini_code_assist_proxy_kv", id = "YOUR_NAMESPACE_ID_HERE" }
+     { binding = "gemini_code_assist_oauth_proxy_kv", id = "YOUR_NAMESPACE_ID_HERE" }
    ]
    ```
 

--- a/cmd/gemini-code-assist-oauth-proxy-worker/main.go
+++ b/cmd/gemini-code-assist-oauth-proxy-worker/main.go
@@ -5,12 +5,12 @@ package main
 import (
 	"fmt"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/credentials"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/env"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/gemini"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/project"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/server"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/credentials"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/env"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/gemini"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/project"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/server"
 	"github.com/syumai/workers"
 )
 

--- a/cmd/gemini-code-assist-oauth-proxy/main.go
+++ b/cmd/gemini-code-assist-oauth-proxy/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"fmt"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/credentials"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/env"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/gemini"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/project"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/server"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/credentials"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/env"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/gemini"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/project"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/server"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dvcrn/gemini-code-assist-proxy
+module github.com/dvcrn/gemini-code-assist-oauth-proxy
 
 go 1.25.7
 

--- a/install-launchagent.sh
+++ b/install-launchagent.sh
@@ -11,12 +11,12 @@ fi
 
 # Get the absolute path of the current directory
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLIST_NAME="com.gemini-proxy.plist"
+PLIST_NAME="sh.d.gemini-code-assist-oauth-proxy.plist"
 PLIST_LOCAL="${PROJECT_DIR}/${PLIST_NAME}"
 LAUNCHAGENTS_DIR="${HOME}/Library/LaunchAgents"
 PLIST_SYMLINK="${LAUNCHAGENTS_DIR}/${PLIST_NAME}"
 
-echo "Installing gemini-proxy LaunchAgent..."
+echo "Installing gemini-code-assist-oauth-proxy LaunchAgent..."
 echo "Project directory: ${PROJECT_DIR}"
 
 # Create LaunchAgents directory if it doesn't exist
@@ -29,7 +29,7 @@ cat > "${PLIST_LOCAL}" <<EOF
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.gemini-proxy</string>
+    <string>sh.d.gemini-code-assist-oauth-proxy</string>
     
     <key>Program</key>
     <string>${PROJECT_DIR}/run_proxy.sh</string>
@@ -52,10 +52,10 @@ cat > "${PLIST_LOCAL}" <<EOF
     <integer>30</integer>
     
     <key>StandardOutPath</key>
-    <string>${HOME}/Library/Logs/gemini-proxy.log</string>
+    <string>${HOME}/Library/Logs/gemini-code-assist-oauth-proxy.log</string>
     
     <key>StandardErrorPath</key>
-    <string>${HOME}/Library/Logs/gemini-proxy.error.log</string>
+    <string>${HOME}/Library/Logs/gemini-code-assist-oauth-proxy.error.log</string>
     
     <key>EnvironmentVariables</key>
     <dict>
@@ -87,7 +87,7 @@ if [ -L "${PLIST_SYMLINK}" ]; then
 fi
 
 # Unload the service if it's already running
-if launchctl list | grep -q "com.gemini-proxy"; then
+if launchctl list | grep -q "sh.d.gemini-code-assist-oauth-proxy"; then
     echo "Unloading existing service..."
     launchctl unload "${PLIST_SYMLINK}" 2>/dev/null || true
 fi
@@ -108,17 +108,17 @@ launchctl load "${PLIST_SYMLINK}"
 
 # Check if the service is running
 sleep 2
-if launchctl list | grep -q "com.gemini-proxy"; then
+if launchctl list | grep -q "sh.d.gemini-code-assist-oauth-proxy"; then
     echo "✅ LaunchAgent installed and started successfully!"
     echo ""
     echo "Service management commands:"
-    echo "  Check status:  launchctl list | grep gemini-proxy"
-    echo "  View logs:     tail -f ~/Library/Logs/gemini-proxy.log"
-    echo "  View errors:   tail -f ~/Library/Logs/gemini-proxy.error.log"
+    echo "  Check status:  launchctl list | grep gemini-code-assist-oauth-proxy"
+    echo "  View logs:     tail -f ~/Library/Logs/gemini-code-assist-oauth-proxy.log"
+    echo "  View errors:   tail -f ~/Library/Logs/gemini-code-assist-oauth-proxy.error.log"
     echo "  Stop service:  launchctl unload ~/Library/LaunchAgents/${PLIST_NAME}"
     echo "  Start service: launchctl load ~/Library/LaunchAgents/${PLIST_NAME}"
     echo "  Uninstall:     ./uninstall-launchagent.sh"
 else
     echo "⚠️  Service may not have started correctly. Check logs at:"
-    echo "  ~/Library/Logs/gemini-proxy.error.log"
+    echo "  ~/Library/Logs/gemini-code-assist-oauth-proxy.error.log"
 fi

--- a/install-systemd-service.sh
+++ b/install-systemd-service.sh
@@ -8,7 +8,7 @@ if [[ "$(uname -s)" != "Linux" ]]; then
 fi
 
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SERVICE_NAME="gemini-code-assist-proxy"
+SERVICE_NAME="gemini-code-assist-oauth-proxy"
 SERVICE_FILE_LOCAL="${PROJECT_DIR}/${SERVICE_NAME}.service"
 SERVICE_FILE_SYSTEM="/etc/systemd/system/${SERVICE_NAME}.service"
 
@@ -31,7 +31,7 @@ echo "Generating systemd unit at ${SERVICE_FILE_LOCAL} (and will install to ${SE
 
 cat > "${SERVICE_FILE_LOCAL}" <<EOF
 [Unit]
-Description=Gemini Code Assist Proxy
+Description=Gemini Code Assist OAuth Proxy
 After=network-online.target
 Wants=network-online.target
 
@@ -41,7 +41,7 @@ WorkingDirectory=${PROJECT_DIR}
 Environment=HOME=${HOME}
 Environment=PORT=${PORT}
 Environment=ADMIN_API_KEY=${ADMIN_API_KEY}
-ExecStart=${PROJECT_DIR}/gemini-code-assist-proxy
+ExecStart=${PROJECT_DIR}/gemini-code-assist-oauth-proxy
 Restart=on-failure
 RestartSec=5
 

--- a/internal/credentials/cloudflare_kv_provider.go
+++ b/internal/credentials/cloudflare_kv_provider.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
 
 	"github.com/syumai/workers/cloudflare/fetch"
 	"github.com/syumai/workers/cloudflare/kv"
@@ -28,7 +28,7 @@ type CloudflareKVProvider struct {
 func NewCloudflareKVProvider() (*CloudflareKVProvider, error) {
 	// In Cloudflare Workers, KV namespaces are accessed via bindings
 	// The binding name is configured in wrangler.toml
-	kvStore, err := kv.NewNamespace("gemini_code_assist_proxy_kv")
+	kvStore, err := kv.NewNamespace("gemini_code_assist_oauth_proxy_kv")
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize KV namespace: %w", err)
 	}

--- a/internal/credentials/file_provider.go
+++ b/internal/credentials/file_provider.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/env"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/env"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
 )
 
 // FileProvider implements CredentialsProvider using file-based storage

--- a/internal/gemini/client.go
+++ b/internal/gemini/client.go
@@ -9,9 +9,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/credentials"
-	serverhttp "github.com/dvcrn/gemini-code-assist-proxy/internal/http"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/credentials"
+	serverhttp "github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/http"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
 )
 
 // Client is a client for the Gemini API.

--- a/internal/openai/stream_transformer.go
+++ b/internal/openai/stream_transformer.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
 	"github.com/google/uuid"
 )
 

--- a/internal/project/discover.go
+++ b/internal/project/discover.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/credentials"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/gemini"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/credentials"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/gemini"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
 )
 
 // Discover determines the GCP Project ID to use for the proxy.

--- a/internal/server/admin_middleware.go
+++ b/internal/server/admin_middleware.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/env"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/env"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
 )
 
 // adminMiddleware checks for valid admin API key from either

--- a/internal/server/chat_completions_handler.go
+++ b/internal/server/chat_completions_handler.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/openai"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/transform"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/openai"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/transform"
 )
 
 // openAIChatCompletionsHandler handles OpenAI-compatible chat completion requests.

--- a/internal/server/gemini_helpers.go
+++ b/internal/server/gemini_helpers.go
@@ -5,9 +5,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/env"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/gemini"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/env"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/gemini"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
 )
 
 var geminiPathRegex = regexp.MustCompile(`v1(?:beta)?/models/([^/:]+):(.+)`)

--- a/internal/server/logging_middleware.go
+++ b/internal/server/logging_middleware.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
 )
 
 // loggingMiddleware logs all incoming requests

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/credentials"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/env"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/gemini"
-	serverhttp "github.com/dvcrn/gemini-code-assist-proxy/internal/http"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/credentials"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/env"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/gemini"
+	serverhttp "github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/http"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
 )
 
 // Server represents the proxy server with its dependencies

--- a/internal/server/stream_generate_content_handler.go
+++ b/internal/server/stream_generate_content_handler.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/gemini"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/gemini"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
 )
 
 func (s *Server) streamGenerateContentHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/transform/gemini_to_openai.go
+++ b/internal/transform/gemini_to_openai.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/gemini"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/openai"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/gemini"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/openai"
 	"github.com/google/uuid"
 )
 

--- a/internal/transform/openai_to_gemini.go
+++ b/internal/transform/openai_to_gemini.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/gemini"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/logger"
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/openai"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/gemini"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/logger"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/openai"
 )
 
 // ToGeminiRequest converts an OpenAI chat completion request to a Gemini generateContent request.

--- a/internal/transform/openai_to_gemini_test.go
+++ b/internal/transform/openai_to_gemini_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/gemini"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/gemini"
 )
 
 func TestConvertToGeminiSchema(t *testing.T) {

--- a/internal/transform/openai_to_gemini_tool_test.go
+++ b/internal/transform/openai_to_gemini_tool_test.go
@@ -3,7 +3,7 @@ package transform
 import (
 	"testing"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/openai"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/openai"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/transform/tool_parity_test.go
+++ b/internal/transform/tool_parity_test.go
@@ -3,7 +3,7 @@ package transform
 import (
 	"testing"
 
-	"github.com/dvcrn/gemini-code-assist-proxy/internal/openai"
+	"github.com/dvcrn/gemini-code-assist-oauth-proxy/internal/openai"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/mise.toml
+++ b/mise.toml
@@ -1,11 +1,11 @@
 
 [tasks.build]
 description = "Build the proxy"
-run = "go build -o gemini-code-assist-proxy ./cmd/gemini-code-assist-proxy"
+run = "go build -o gemini-code-assist-oauth-proxy ./cmd/gemini-code-assist-oauth-proxy"
 
 [tasks.run]
 description = "Run the proxy"
-run = "go run ./cmd/gemini-code-assist-proxy"
+run = "go run ./cmd/gemini-code-assist-oauth-proxy"
 
 [tasks.test]
 description = "Run all tests"
@@ -40,7 +40,7 @@ run = [
 description = "Build for Cloudflare Workers"
 run = [
   "go run github.com/syumai/workers/cmd/workers-assets-gen -mode=go",
-  "GOOS=js GOARCH=wasm go build -o ./build/app.wasm cmd/gemini-code-assist-proxy-worker/main.go",
+  "GOOS=js GOARCH=wasm go build -o ./build/app.wasm cmd/gemini-code-assist-oauth-proxy-worker/main.go",
 ]
 
 [tasks."wrangler-dev"]

--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,2 +1,2 @@
-gemini-code-assist-proxy
-gemini-code-assist-proxy.exe
+gemini-code-assist-oauth-proxy
+gemini-code-assist-oauth-proxy.exe

--- a/npm/index.js
+++ b/npm/index.js
@@ -5,7 +5,7 @@ const { spawn } = require("child_process");
 
 const { startUpdateCheck } = require("./update_check");
 
-const exe = process.platform === "win32" ? "gemini-code-assist-proxy.exe" : "gemini-code-assist-proxy";
+const exe = process.platform === "win32" ? "gemini-code-assist-oauth-proxy.exe" : "gemini-code-assist-oauth-proxy";
 const binPath = path.join(__dirname, exe);
 
 const PKG = (() => {

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "@dvcrn/gemini-code-assist-proxy",
+  "name": "@dvcrn/gemini-code-assist-oauth-proxy",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@dvcrn/gemini-code-assist-proxy",
+      "name": "@dvcrn/gemini-code-assist-oauth-proxy",
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
         "semver": "^7.7.4"
       },
       "bin": {
-        "gemini-code-assist-proxy": "index.js"
+        "gemini-code-assist-oauth-proxy": "index.js"
       }
     },
     "node_modules/semver": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@dvcrn/gemini-code-assist-proxy",
+  "name": "@dvcrn/gemini-code-assist-oauth-proxy",
   "version": "1.0.0",
-  "description": "Release package for gemini-code-assist-proxy",
+  "description": "Release package for gemini-code-assist-oauth-proxy",
   "scripts": {
     "postinstall": "node postinstall.js"
   },
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "bin": {
-    "gemini-code-assist-proxy": "index.js"
+    "gemini-code-assist-oauth-proxy": "index.js"
   },
   "dependencies": {
     "semver": "^7.7.4"

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -7,8 +7,8 @@ const crypto = require("crypto");
 const { spawnSync } = require("child_process");
 
 const OWNER = "dvcrn";
-const REPO = "gemini-code-assist-proxy";
-const BIN = "gemini-code-assist-proxy";
+const REPO = "gemini-code-assist-oauth-proxy";
+const BIN = "gemini-code-assist-oauth-proxy";
 const VERSION_ENV = "GEMINI_CODE_ASSIST_PROXY_VERSION";
 const BASE_URL_ENV = "GEMINI_CODE_ASSIST_PROXY_BASE_URL";
 const ARCH_ENV = "GEMINI_CODE_ASSIST_PROXY_ARCH";
@@ -71,7 +71,7 @@ function parseChecksums(text) {
     const platform = platformRaw === "win32" ? "windows" : platformRaw;
     if (!["darwin", "linux", "windows"].includes(platform)) {
       console.error(
-        "gemini-code-assist-proxy: npm install supports macOS (darwin), Linux, and Windows only"
+        "gemini-code-assist-oauth-proxy: npm install supports macOS (darwin), Linux, and Windows only"
       );
       process.exit(1);
     }

--- a/npm/update_check.js
+++ b/npm/update_check.js
@@ -4,9 +4,9 @@ const os = require("os");
 const https = require("https");
 const semver = require("semver");
 
-const DEFAULT_PACKAGE_NAME = "@dvcrn/gemini-code-assist-proxy";
-const DEFAULT_UPDATE_COMMAND = "npm install -g @dvcrn/gemini-code-assist-proxy";
-const CACHE_DIR_NAME = "gemini-code-assist-proxy";
+const DEFAULT_PACKAGE_NAME = "@dvcrn/gemini-code-assist-oauth-proxy";
+const DEFAULT_UPDATE_COMMAND = "npm install -g @dvcrn/gemini-code-assist-oauth-proxy";
+const CACHE_DIR_NAME = "gemini-code-assist-oauth-proxy";
 
 const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const UPDATE_CHECK_TIMEOUT_MS = 1200;

--- a/run_proxy.sh
+++ b/run_proxy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 #!/bin/bash
-direnv exec . go run cmd/gemini-code-assist-proxy/main.go
+direnv exec . go run cmd/gemini-code-assist-oauth-proxy/main.go

--- a/uninstall-launchagent.sh
+++ b/uninstall-launchagent.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLIST_NAME="com.gemini-proxy.plist"
+PLIST_NAME="sh.d.gemini-code-assist-oauth-proxy.plist"
 PLIST_LOCAL="${PROJECT_DIR}/${PLIST_NAME}"
 PLIST_SYMLINK="${HOME}/Library/LaunchAgents/${PLIST_NAME}"
 
-echo "Uninstalling gemini-proxy LaunchAgent..."
+echo "Uninstalling gemini-code-assist-oauth-proxy LaunchAgent..."
 
 # Check if the service is running and unload it
-if launchctl list | grep -q "com.gemini-proxy"; then
+if launchctl list | grep -q "sh.d.gemini-code-assist-oauth-proxy"; then
     echo "Stopping service..."
     launchctl unload "${PLIST_SYMLINK}" 2>/dev/null || true
     echo "Service stopped"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "gemini-code-assist-proxy"
+name = "gemini-code-assist-oauth-proxy"
 main = "build/worker.mjs"
 compatibility_date = "2022-05-13"
 account_id = "02c07a2514d9a25f58c78a180bb8c6f3"
@@ -6,7 +6,7 @@ compatibility_flags = [
     "streams_enable_constructors"
 ]
 kv_namespaces = [
-  { binding = "gemini_code_assist_proxy_kv", id = "2c683e97ff6a43c7b20edca20419bd1f" }
+  { binding = "gemini_code_assist_oauth_proxy_kv", id = "2c683e97ff6a43c7b20edca20419bd1f" }
 ]
 
 [vars]


### PR DESCRIPTION
## Summary

Renames the Go package/project from `gemini-code-assist-proxy` to `gemini-code-assist-oauth-proxy` across the whole codebase, and adds a deprecation notice to the README.

## Changes

- **Go module**: `github.com/dvcrn/gemini-code-assist-proxy` → `github.com/dvcrn/gemini-code-assist-oauth-proxy`, with all import paths updated.
- **cmd directories**: renamed `cmd/gemini-code-assist-proxy` and `cmd/gemini-code-assist-proxy-worker` to the `-oauth-` variants.
- **npm package**: `@dvcrn/gemini-code-assist-proxy` → `@dvcrn/gemini-code-assist-oauth-proxy` (package.json, package-lock.json, bin names, postinstall/update-check scripts, `.npmignore`).
- **Cloudflare Workers**: `wrangler.toml` name + KV binding `gemini_code_assist_proxy_kv` → `gemini_code_assist_oauth_proxy_kv` (and the matching `kv.NewNamespace` call).
- **Config/build**: `.goreleaser.yml`, `mise.toml`, `run_proxy.sh`, `install-systemd-service.sh`, `.gitignore`.
- **Docs**: README title, install/usage instructions, and project guide references all updated.
- **README deprecation notice**: added a warning at the top noting Google has deprecated Gemini Code Assist in favor of [Antigravity](https://antigravity.google/), linking to [antigravity-oauth-proxy](https://github.com/dvcrn/antigravity-oauth-proxy).

## Verification

- `go build ./...` — passes
- `go test ./...` — all packages pass
- Formatted with goimports + gofumpt

## Note

The GitHub repository itself was also renamed (`dvcrn/gemini-code-assist-proxy` → `gemini-code-assist-oauth-proxy`); GitHub keeps automatic redirects from the old URL.